### PR TITLE
if  use too much count option, use range will cause use too much memory.

### DIFF
--- a/es_test_data.py
+++ b/es_test_data.py
@@ -218,7 +218,7 @@ def generate_test_data():
 
     logging.info("Generating %d docs, upload batch size is %d" % (tornado.options.options.count,
                                                                   tornado.options.options.batch_size))
-    for num in range(0, tornado.options.options.count):
+    for num in xrange(0, tornado.options.options.count):
 
         item = generate_random_doc(format)
 


### PR DESCRIPTION
Range will cause use too much memory even cause kill by oomkiller, use xrange instead