### PR TITLE
fix python3 didn't have xrange function

### DIFF
--- a/es_test_data.py
+++ b/es_test_data.py
@@ -13,6 +13,12 @@ import tornado.httpclient
 import tornado.ioloop
 import tornado.options
 
+try:
+    xrange
+    range = xrange
+except NameError:
+    pass
+
 async_http_client = tornado.httpclient.AsyncHTTPClient()
 headers = tornado.httputil.HTTPHeaders({"content-type": "application/json"})
 id_counter = 0
@@ -218,7 +224,7 @@ def generate_test_data():
 
     logging.info("Generating %d docs, upload batch size is %d" % (tornado.options.options.count,
                                                                   tornado.options.options.batch_size))
-    for num in xrange(0, tornado.options.options.count):
+    for num in range(0, tornado.options.options.count):
 
         item = generate_random_doc(format)
 


### PR DESCRIPTION
If has xrange function, use xrange. otherwise use range instead.