### PR TITLE
[Fix] Nest AsyncIO

### DIFF
--- a/es_test_data.py
+++ b/es_test_data.py
@@ -1,5 +1,8 @@
 #!/usr/bin/python
 
+import nest_asyncio
+nest_asyncio.apply()
+
 import json
 import time
 import logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tornado==4.5.3
+nest-asyncio=1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 tornado==4.5.3
-nest-asyncio=1.5.1
+nest-asyncio==1.5.1


### PR DESCRIPTION
Hi, without this on Python 3.9 on Windows you got an error:
`Cannot run the event loop while another loop is running`

This requires another pip package: *nest_asyncio*