### PR TITLE
Add support for adding test data from external source

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ ptions, here are the most important ones:
 - `--dict_file=filename.dic` if provided the `dict` data type will use words
   from the dictionary file, format is one word per line. The entire file is
   loaded at start-up so be careful with (very) large files.
+- `--data_file=filename.json|filename.csv` 
 
 ## What about the document format?
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ ptions, here are the most important ones:
 - `--dict_file=filename.dic` if provided the `dict` data type will use words
   from the dictionary file, format is one word per line. The entire file is
   loaded at start-up so be careful with (very) large files.
-- `--data_file=filename.json|filename.csv` 
+- `--data_file=filename.json|filename.csv` if provided all data in the filename will be inserted into es. The file content has to be an array of json objects (the documents). If the file ends in `.csv` then the data is automatically converted into json and inserted as documents.
 
 ## What about the document format?
 


### PR DESCRIPTION
This PR aims at adding data from external source using the new ```data_file``` parameter.
The data can be either in json format directly (an array of json objects which will act as new documents) or if the filename ends in ```.csv``` then the data can also be passed as csv (useful for importing data from excel for instance).

This expands the use case of this tool to also allowing external data to be easily inserted into ES.

Example json file:
```json
[
	{
		"testField": "testvalue"
	},
	{
		"field": "myNiceValue",
		"anotherField": "myValue"
	},
	{
		"field": "anotherNiceValue",
		"anotherField": "anotherValue",
		"extraField": "extraValue"
	}
]
```

Example csv:
```csv
field1,field2,field3,field4
test1,test2,test3,test4
another1,another2,another3,another4
well1,well2,well3,well4
whynot1,whynot2,whynot3,whynot4
```