### PR TITLE
Fixing bug that broke batch updates

### DIFF
--- a/es_test_data.py
+++ b/es_test_data.py
@@ -280,9 +280,9 @@ def generate_test_data():
                 yield upload_batch(upload_data_txt)
                 upload_data_txt = ""
 
-            # upload remaining items in `upload_data_txt`
-            if upload_data_txt:
-                yield upload_batch(upload_data_txt)
+        # upload remaining items in `upload_data_txt`
+        if upload_data_txt:
+            yield upload_batch(upload_data_txt)
 
     if tornado.options.options.set_refresh:
         set_index_refresh("1s")


### PR DESCRIPTION
PR https://github.com/oliver006/elasticsearch-test-data/pull/32 introduced bug related to uploading data to ELS each time when new record is created instead of doing this upload only once at the end of batches creation. Simple indentation issue.