### PR TITLE
Support for arrays in generated documents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Currently supported field types are:
   given list of `-` seperated words, the words are optional defaulting to
   `text1` `text2` and `text3`, min and max are optional, defaulting to `1`
   and `1`
+- `arr:[array_length_expression]:[single_element_format]` an array of entries 
+  with format specified by `single_element_format`. `array_length_expression` 
+  can be either a single number, or pair of numbers separated by `-` (i.e. 3-7), 
+  defining range of lengths from with random length will be picked for each array
+  (Example `int_array:arr:1-5:int:1:250`)
+
 
 ## Todo
 

--- a/es_test_data.py
+++ b/es_test_data.py
@@ -92,7 +92,21 @@ def get_data_for_format(format):
 
     return_val = ''
 
-    if field_type == "bool":
+    if field_type == 'arr':
+        return_val = []
+        array_len_expr = split_f[2]
+        if '-' in array_len_expr:
+            (min,max) = array_len_expr.split('-')
+            array_len = generate_count(int(min), int(max))
+        else:
+            array_len = int(array_len_expr)
+
+        single_elem_format = field_name + ':' + format[len(field_name) + len(field_type) + len(array_len_expr) + 3 : ]
+        for i in range(array_len):
+            x = get_data_for_format(single_elem_format)
+            return_val.append(x[1])
+
+    elif field_type == "bool":
         return_val = random.choice([True, False])
 
     elif field_type == "str":


### PR DESCRIPTION
**Support for arrays in generated documents.**

With a format expression like this one:
_--format=timestamp:tstxt,message:str,source:str:2:3,**int_array:arr:1-5:int:1:250**_


We can now generate documents that look like this one:
       _"_source" : {
          "timestamp" : "2022-10-21T22:11:58.000-0000",
          "message" : "cOzaaM3I",
          "source" : "Nf",
          **"int_array" : [
            215,
            128
          ]**
        }_